### PR TITLE
Limit code blocks visible lines count

### DIFF
--- a/panel_hider.js
+++ b/panel_hider.js
@@ -36,12 +36,21 @@ function checkLeftPanel() {
 	}
 }
 
+function checkCodeBlocks() {
+	var codeBlocks = document.getElementsByClassName('code-block');
+	for (var i = 0; i < codeBlocks.length; i++) {
+		element = codeBlocks.item(i);
+		element.childNodes[0].childNodes[0].style.maxHeight = '40em';
+	}
+}
+
 function observeChanges() {
   'use strict';
   var observer = new MutationObserver(function(mutations) {
   console.log(document.readyState)
 	checkRightPanel();
 	checkLeftPanel();
+	checkCodeBlocks();
   });
   observer.observe(document, {
     childList: true,


### PR DESCRIPTION
Fix code blocks to style to limit visible lines count, use vertical
scroll for long blocks.